### PR TITLE
Split hooks folder into separate subpath import

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,15 @@
   "license": "MIT",
   "description": "Declarative and type-safe model & validation library",
   "author": "Smartly.io",
-  "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "default": "./dist/index.js",
+      "types": "./dist/index.d.ts"},
+    "./hooks": {
+      "default": "./dist/hooks/index.js",
+      "types": "./dist/hooks/index.d.ts"}
+  },
   "scripts": {
     "build": "yarn clean && yarn tsc -p tsconfig.dist.json",
     "typecheck": "yarn tsc",

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,8 +23,6 @@ export { transaction } from './transaction';
 export { getAnnotationValue } from './getAnnotationValue';
 export { default as isModelContext } from './utils/isModelContext';
 
-export * from './hooks';
-
 export type WhenFn<If = never, Else = never, ErrorType = string> = (
   ifFn: [If] extends [never]
     ? ModelDefinitionFnWithNoArg<ErrorType>

--- a/tsconfig.dist.json
+++ b/tsconfig.dist.json
@@ -5,6 +5,6 @@
     "noEmit": false,
     "declaration": true
   },
-  "files": ["./src/index.ts"],
+  "files": ["./src/index.ts", "./src/hooks/index.ts"],
   "include": []
 }


### PR DESCRIPTION
hooks folder creates a dependency to react which is unwanted if we want to run YAVL in node environment.
Instead of exporting hooks from main index, we'll create a separate subpath import for that one. 

**This means in practice that hook code imports need to be updated from** `@smartlyio/yavl` to `@smartlyio/yavl/hooks`