### PR TITLE
Fix variable reference copy paste error

### DIFF
--- a/.github/workflows/release_package.yml
+++ b/.github/workflows/release_package.yml
@@ -36,7 +36,7 @@ jobs:
 
       # Publish version to public repository
       - name: Publish
-        run: lerna publish ${{ env.github.event.inputs.release-type }} --no-private --force-publish --loglevel verbose --yes
+        run: lerna publish ${{ github.event.inputs.release-type }} --no-private --force-publish --loglevel verbose --yes
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPMJS_ACCESS_TOKEN }}
 


### PR DESCRIPTION
Yep, so it was copy paste issue. There shouldn't be env. prefix on github release type 😄 