### PR TITLE
Adjust publish script once more

### DIFF
--- a/.github/workflows/release_package.yml
+++ b/.github/workflows/release_package.yml
@@ -39,7 +39,7 @@ jobs:
 
       # Publish version to public repository
       - name: Publish
-        run: lerna publish ${{ github.event.inputs.release-type }} --include-private --force-publish --loglevel verbose --yes
+        run: lerna publish ${{ github.event.inputs.release-type }} --loglevel verbose --yes
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPMJS_ACCESS_TOKEN }}
 


### PR DESCRIPTION
Let's remove the --force-publish that we used for testing purposes. Also we don't need to have --include-private flag since both packages are public.