### PR TITLE
add publish configs so we can create new scoped packages under smartly

### DIFF
--- a/packages/yavl-hooks/package.json
+++ b/packages/yavl-hooks/package.json
@@ -15,6 +15,9 @@
     "url": "https://github.com/smartlyio/yavl.git",
     "directory": "packages/yavl-hooks"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "peerDependencies": {
     "typescript": ">=4 <6"
   },

--- a/packages/yavl/package.json
+++ b/packages/yavl/package.json
@@ -15,6 +15,9 @@
     "url": "https://github.com/smartlyio/yavl.git",
     "directory": "packages/yavl"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "peerDependencies": {
     "typescript": ">=4 <6"
   },


### PR DESCRIPTION
New scoped packages are created as private by default, so trying to publish yavl-hooks will fail on CI. Add explicit publishConfigs to package.json which will address the issue. 