### PR TITLE
List ramda as a package dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,9 +21,6 @@
     "test:watch": "yarn jest --watch",
     "test:all": "yarn lint && yarn test"
   },
-  "dependencies": {
-    "ramda": "^0.28.0"
-  },
   "keywords": [
     "typescript",
     "server",

--- a/packages/yavl-hooks/package.json
+++ b/packages/yavl-hooks/package.json
@@ -22,7 +22,8 @@
     "typescript": ">=4 <6"
   },
   "dependencies": {
-    "@smartlyio/yavl": "^7.0.1"
+    "@smartlyio/yavl": "^7.0.1",
+    "ramda": "^0.28.0"
   },
   "keywords": [
     "typescript",

--- a/packages/yavl/package.json
+++ b/packages/yavl/package.json
@@ -21,6 +21,9 @@
   "peerDependencies": {
     "typescript": ">=4 <6"
   },
+  "dependencies": {
+    "ramda": "^0.28.0"
+  },
   "keywords": [
     "typescript",
     "server",


### PR DESCRIPTION
List ramda as a package dependency instead of root dep. Root dependencies wont be included as a dependency in published package so we cannot use that.