### PR TITLE
Optimise performance by avoiding R._assoc

### DIFF
--- a/packages/yavl/src/utils/resolvedValidationsHelpers.ts
+++ b/packages/yavl/src/utils/resolvedValidationsHelpers.ts
@@ -17,10 +17,11 @@ export const updateResolvedValidationErrors = <ErrorType>(
   field: string,
   errors: ErrorType[] | undefined,
 ): void => {
+  resolvedValidations.current = { ...resolvedValidations.current };
   if (errors !== undefined) {
-    resolvedValidations.current = R.assoc(field, R.uniq(errors), resolvedValidations.current);
+    resolvedValidations.current[field] = R.uniq(errors);
   } else {
     // delete errors from field
-    resolvedValidations.current = R.dissoc(field, resolvedValidations.current);
+    delete resolvedValidations.current[field];
   }
 };

--- a/packages/yavl/src/validate/notifySubscribers.ts
+++ b/packages/yavl/src/validate/notifySubscribers.ts
@@ -61,16 +61,18 @@ const getNextValueForAnnotationsSubscription = (
   value: unknown,
 ): AnnotationsSubscriptionValue => {
   if (value === noValue) {
-    const nextValue = R.dissocPath<AnnotationsSubscriptionValue>([path, annotation], subscription.previousValue);
+    const nextValue = { ...subscription.previousValue };
+    const keys = Object.keys(nextValue[path]);
 
-    if (R.isEmpty(R.path([path], nextValue))) {
-      return R.dissocPath([path], subscription.previousValue);
+    if ((keys.length === 1 && keys[0] === annotation) || keys.length === 0) {
+      delete nextValue[path];
+      return nextValue;
     }
 
     return nextValue;
   }
 
-  return R.assocPath([path, annotation], value, subscription.previousValue);
+  return { ...subscription.previousValue, [path]: { ...subscription.previousValue[path], [annotation]: value } };
 };
 
 const updateAndNotifyAnnotationSubscribers = (


### PR DESCRIPTION
Internal task ticket: [MAVE-1804](https://smartlyio.atlassian.net/browse/MAVE-1804).

`R._assoc` is known to have terrible performance. Read the [source code](https://github.com/ramda/ramda/blob/master/source/internal/_assoc.js) if you wish to know why.

I found a surprisingly large chunk of `dissocPath` in a performance profile which led me to suspect `assoc`. `assocPath` and `dissocPath` internally use `_assoc`.

I profiled with this versus v7.0.2. In my test case I consistently got execution times of 1.9s and 2.3s respectively for `updateModel`. That's about 1/8.

This PR replaces the low-hanging fruit cases of ramda usage with regular JavaScript. It's not as pretty but it runs a lot better.

[MAVE-1804]: https://smartlyio.atlassian.net/browse/MAVE-1804?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ