### PR TITLE
Fix crashing bug on reading keys of null

### DIFF
--- a/packages/yavl/src/validate/notifySubscribers.ts
+++ b/packages/yavl/src/validate/notifySubscribers.ts
@@ -62,9 +62,9 @@ const getNextValueForAnnotationsSubscription = (
 ): AnnotationsSubscriptionValue => {
   if (value === noValue) {
     const nextValue = { ...subscription.previousValue };
-    const keys = Object.keys(nextValue[path]);
+    const keys = nextValue[path] == null ? null : Object.keys(nextValue[path]);
 
-    if ((keys.length === 1 && keys[0] === annotation) || keys.length === 0) {
+    if ((keys == null || keys.length === 1 && keys[0] === annotation) || keys.length === 0) {
       delete nextValue[path];
       return nextValue;
     }


### PR DESCRIPTION
7.0.3 introduced a regression where a rare case could crash when a path is assumed populated but actually nullish.

This PR restores the 7.0.2 behaviour where the path is deleted. The path is most likely not defined if it's nulliish so it doesn't really matter which way the behaviour is.