### PR TITLE
Replace low-hanging fruit Ramda function usages with vanilla alternatives

### DIFF
--- a/packages/yavl/src/builder/filter.ts
+++ b/packages/yavl/src/builder/filter.ts
@@ -1,4 +1,3 @@
-import * as R from 'ramda';
 import {
   AnyArrayModelContext,
   ContextType,
@@ -16,6 +15,7 @@ import compute from './compute';
 import isComputedContext from '../utils/isComputedContext';
 import { ExtractDependencies } from './dependency';
 import isAnyArrayModelContext from '../utils/isAnyArrayModelContext';
+import { pick } from '../utils/pick';
 
 /**
  * TODO:
@@ -91,7 +91,7 @@ const filter: FilterBuilderFn = (
       },
       ({ array, deps }) =>
         array.filter((value, index) =>
-          hasDependencies ? filterFn(R.pick(keys, value), deps, index) : filterFn(R.pick(keys, value), index),
+          hasDependencies ? filterFn(pick(keys, value), deps, index) : filterFn(pick(keys, value), index),
         ),
     );
   }

--- a/packages/yavl/src/builder/pick.ts
+++ b/packages/yavl/src/builder/pick.ts
@@ -1,8 +1,8 @@
-import * as R from 'ramda';
 import { AnyContext, ContextType, KeysOfUnion, SameContextOfType } from '../types';
 import compute from './compute';
 import isComputedContext from '../utils/isComputedContext';
 import { isPreviousContext } from '../utils/isPreviousContext';
+import { pick as utilPick } from '../utils/pick';
 
 export interface PickBuilderFn {
   <
@@ -21,7 +21,7 @@ export interface PickBuilderFn {
 const pick: PickBuilderFn = (context: AnyContext<any>, keys: readonly string[]): any => {
   if (isComputedContext(context) || isPreviousContext(context)) {
     // we can't use dependsOn on for computed data, we must depend on the whole computed data
-    return compute(context, R.pick(keys));
+    return compute(context, utilPick.bind(null, keys));
   } else {
     return {
       ...context,

--- a/packages/yavl/src/model.ts
+++ b/packages/yavl/src/model.ts
@@ -1,4 +1,3 @@
-import * as R from 'ramda';
 import as, { AsFn } from './builder/as';
 import nthFocus, { NthFocusFn } from './builder/nthFocus';
 import field, { FieldFn } from './builder/field';
@@ -30,6 +29,7 @@ import log, { LogFn } from './builder/log';
 import { getFieldsWithDependencies } from './getFieldsWithDependencies';
 import { PassiveFn, passive } from './builder/passive';
 import { PreviousBuilderFn, previous } from './builder/previous';
+import { isEmpty } from './utils/isEmpty';
 
 export type ModelBuilder<FormData, ExternalData = undefined, ErrorType = string> = {
   as: AsFn;
@@ -73,7 +73,7 @@ export type ModelOptions = {
   testRequiredFn: (value: any) => boolean;
 };
 
-export const defaultTestRequiredFn = (value: any) => value != null && !R.isEmpty(value);
+export const defaultTestRequiredFn = (value: any) => value != null && !isEmpty(value);
 
 export interface ModelFn {
   <FormData, ExternalData = undefined, ErrorType = string>(

--- a/packages/yavl/src/model.ts
+++ b/packages/yavl/src/model.ts
@@ -73,7 +73,7 @@ export type ModelOptions = {
   testRequiredFn: (value: any) => boolean;
 };
 
-export const defaultTestRequiredFn = (value: any) => !R.isNil(value) && !R.isEmpty(value);
+export const defaultTestRequiredFn = (value: any) => value != null && !R.isEmpty(value);
 
 export interface ModelFn {
   <FormData, ExternalData = undefined, ErrorType = string>(

--- a/packages/yavl/src/subscribeToAnnotations.ts
+++ b/packages/yavl/src/subscribeToAnnotations.ts
@@ -1,4 +1,3 @@
-import * as R from 'ramda';
 import {
   Annotation,
   AnnotationsSubscription,
@@ -8,6 +7,7 @@ import {
   UnsubscribeFn,
 } from './types';
 import { ModelValidationContext } from './validate/types';
+import { isEmpty } from './utils/isEmpty';
 
 interface SubscribeToAnnotations {
   // subscribes to all annotations
@@ -36,7 +36,7 @@ const getInitialValue = (
 
       const filteredAnnotationData = annotations ? R.pick(annotations, annotationData) : annotationData;
 
-      if (R.isEmpty(filteredAnnotationData)) {
+      if (isEmpty(filteredAnnotationData)) {
         return acc;
       }
 

--- a/packages/yavl/src/subscribeToAnnotations.ts
+++ b/packages/yavl/src/subscribeToAnnotations.ts
@@ -8,6 +8,7 @@ import {
 } from './types';
 import { ModelValidationContext } from './validate/types';
 import { isEmpty } from './utils/isEmpty';
+import { pick } from './utils/pick';
 
 interface SubscribeToAnnotations {
   // subscribes to all annotations
@@ -34,7 +35,7 @@ const getInitialValue = (
         return acc;
       }
 
-      const filteredAnnotationData = annotations ? R.pick(annotations, annotationData) : annotationData;
+      const filteredAnnotationData = annotations ? pick(annotations, annotationData) : annotationData;
 
       if (isEmpty(filteredAnnotationData)) {
         return acc;

--- a/packages/yavl/src/utils/isEmpty.spec.ts
+++ b/packages/yavl/src/utils/isEmpty.spec.ts
@@ -1,0 +1,75 @@
+import { isEmpty } from './isEmpty';
+
+// Copied from ramda 0.30.1
+describe('isEmpty', function () {
+  it('returns false for null', function () {
+    expect(isEmpty(null)).toBe(false);
+  });
+
+  it('returns false for undefined', function () {
+    expect(isEmpty(undefined)).toBe(false);
+  });
+
+  it('returns true for empty string', function () {
+    expect(isEmpty('')).toBe(true);
+    expect(isEmpty(' ')).toBe(false);
+  });
+
+  it('returns true for empty array', function () {
+    expect(isEmpty([])).toBe(true);
+    expect(isEmpty([[]])).toBe(false);
+  });
+
+  it('returns true for empty typed array', function () {
+    // @ts-ignore
+    expect(isEmpty(Uint8Array.from(''))).toBe(true);
+    // @ts-ignore
+    expect(isEmpty(Float32Array.from(''))).toBe(true);
+    expect(isEmpty(new Float32Array([]))).toBe(true);
+    // @ts-ignore
+    expect(isEmpty(Uint8Array.from('1'))).toBe(false);
+    // @ts-ignore
+    expect(isEmpty(Float32Array.from('1'))).toBe(false);
+    expect(isEmpty(new Float32Array([1]))).toBe(false);
+  });
+
+  it('returns true for empty object', function () {
+    expect(isEmpty({})).toBe(true);
+    expect(isEmpty({ x: 0 })).toBe(false);
+  });
+
+  it('returns true for empty arguments object', function () {
+    expect(
+      isEmpty(
+        (function () {
+          // eslint-disable-next-line prefer-rest-params
+          return arguments;
+        })(),
+      ),
+    ).toBe(true);
+    expect(
+      isEmpty(
+        (function (_) {
+          // eslint-disable-next-line prefer-rest-params
+          return arguments;
+        })(0),
+      ),
+    ).toBe(false);
+  });
+
+  it('returns false for every other value', function () {
+    expect(isEmpty(0)).toBe(false);
+    expect(isEmpty(NaN)).toBe(false);
+    expect(isEmpty([''])).toBe(false);
+  });
+
+  it('returns true for empty Set', function () {
+    expect(isEmpty(new Set())).toBe(true);
+    expect(isEmpty(new Set([1]))).toBe(false);
+  });
+
+  it('returns true for empty Map', function () {
+    expect(isEmpty(new Map())).toBe(true);
+    expect(isEmpty(new Map([['a', 1]]))).toBe(false);
+  });
+});

--- a/packages/yavl/src/utils/isEmpty.ts
+++ b/packages/yavl/src/utils/isEmpty.ts
@@ -1,0 +1,34 @@
+const typedArrayConstructors = new Set([
+  '[object Uint8ClampedArray]',
+  '[object Int8Array]',
+  '[object Uint8Array]',
+  '[object Int16Array]',
+  '[object Uint16Array]',
+  '[object Int32Array]',
+  '[object Uint32Array]',
+  '[object Float32Array]',
+  '[object Float64Array]',
+  '[object BigInt64Array]',
+  '[object BigUint64Array]',
+]);
+
+export const isEmpty = (value: unknown) => {
+  switch (typeof value) {
+    case 'string':
+      return value === '';
+    case 'object':
+      if (value === null) {
+        return false;
+      } else if (Array.isArray(value)) {
+        return value.length === 0;
+      } else if (value instanceof Set || value instanceof Map) {
+        return value.size === 0;
+      } else if (value.constructor === Object) {
+        return Object.keys(value).length === 0;
+      } else if (typedArrayConstructors.has(Object.prototype.toString.call(value))) {
+        return (value as unknown[]).length === 0;
+      }
+    default:
+      return false;
+  }
+};

--- a/packages/yavl/src/utils/pick.spec.ts
+++ b/packages/yavl/src/utils/pick.spec.ts
@@ -1,0 +1,31 @@
+import { pick } from './pick';
+
+// Copied from ramda 0.30.1
+describe('pick', function () {
+  const obj = { a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, 1: 7 };
+
+  it('copies the named properties of an object to the new object', function () {
+    expect(pick(['a', 'c', 'f'], obj)).toEqual({ a: 1, c: 3, f: 6 });
+  });
+
+  it('handles numbers as properties', function () {
+    expect(pick([1], obj)).toEqual({ 1: 7 });
+  });
+
+  it('ignores properties not included', function () {
+    expect(pick(['a', 'c', 'g'], obj)).toEqual({ a: 1, c: 3 });
+  });
+
+  it('retrieves prototype properties', function () {
+    const F = function (this: Record<'x', unknown>, param: unknown) {
+      this.x = param;
+    };
+    F.prototype.y = 40;
+    F.prototype.z = 50;
+    // @ts-ignore
+    const obj = new F(30);
+    obj.v = 10;
+    obj.w = 20;
+    expect(pick(['w', 'x', 'y'], obj)).toEqual({ w: 20, x: 30, y: 40 });
+  });
+});

--- a/packages/yavl/src/utils/pick.ts
+++ b/packages/yavl/src/utils/pick.ts
@@ -1,0 +1,4 @@
+export const pick = <T extends object, K extends string | number>(keys: readonly K[], obj: T) =>
+  Object.fromEntries(
+    keys.filter((key): key is K & keyof T => key in obj).map(key => [key, obj[key]]),
+  ) as T extends Record<string, unknown> ? Pick<T, `${K}`> : T;

--- a/packages/yavl/src/validate/getValidationErrors.ts
+++ b/packages/yavl/src/validate/getValidationErrors.ts
@@ -1,10 +1,10 @@
-import * as R from 'ramda';
 import { ModelValidationErrors, ModelValidationContext } from './types';
+import { isEmpty } from '../utils/isEmpty';
 
 const getValidationErrors = <ErrorType>(
   context: ModelValidationContext<any, any, ErrorType>,
 ): ModelValidationErrors<ErrorType> => {
-  return R.isEmpty(context.resolvedValidations.current) ? undefined : context.resolvedValidations.current;
+  return isEmpty(context.resolvedValidations.current) ? undefined : context.resolvedValidations.current;
 };
 
 export default getValidationErrors;

--- a/packages/yavl/src/validate/resolveDependency.ts
+++ b/packages/yavl/src/validate/resolveDependency.ts
@@ -5,6 +5,7 @@ import { getResolvedAnnotation } from '../utils/resolvedAnnotationsHelpers';
 import { assertUnreachable } from '../utils/typeUtils';
 import resolveDependencies from './resolveDependencies';
 import { MutatingFieldProcessingCacheEntry, ProcessingContext } from './types';
+import { pick } from '../utils/pick';
 
 type DependencyReducerContext = {
   data: any;
@@ -241,7 +242,7 @@ const resolveDependency = <Data, ExternalData, ErrorType>(
          * If we are dealing with an array, we want to pick the keys
          * from every array element, otherwise pick from the object
          */
-        const narrowFn = Array.isArray(data) ? R.project(pathPart.keys) : R.pick(pathPart.keys);
+        const narrowFn = Array.isArray(data) ? R.project(pathPart.keys) : pick.bind(null, pathPart.keys);
 
         return {
           ...acc,
@@ -253,7 +254,7 @@ const resolveDependency = <Data, ExternalData, ErrorType>(
         }
 
         const filteredDataWithIndices = data.flatMap((value, index) => {
-          const pickedKeys = R.pick(pathPart.keys, value);
+          const pickedKeys = pick(pathPart.keys, value);
           let isFiltered: boolean;
 
           if ('dependencies' in pathPart) {

--- a/packages/yavl/src/validate/resolveDependency.ts
+++ b/packages/yavl/src/validate/resolveDependency.ts
@@ -32,7 +32,7 @@ const resolveDependency = <Data, ExternalData, ErrorType>(
         if (isFocusedOnSinglePath) {
           return {
             ...acc,
-            data: R.prop(pathPart.name, data),
+            data: data?.[pathPart.name],
             paths: paths.map(path => path.concat(pathPart.name)),
           };
         } else {
@@ -78,7 +78,7 @@ const resolveDependency = <Data, ExternalData, ErrorType>(
           if (isSingleFocus) {
             return {
               ...acc,
-              data: R.prop(pathPart.index, data),
+              data: data?.[pathPart.index],
               paths: indexedPaths,
               isFocusedOnSinglePath: true,
             };
@@ -128,7 +128,7 @@ const resolveDependency = <Data, ExternalData, ErrorType>(
 
           return {
             ...acc,
-            data: isFocusedOnSinglePath ? R.prop(currentIndex, data) : R.pluck(currentIndex, data as any[]),
+            data: isFocusedOnSinglePath ? data?.[currentIndex] : R.pluck(currentIndex, data as any[]),
             paths: paths.map(path => path.concat(currentIndex)),
           };
         } else {


### PR DESCRIPTION
In the interest of making YAVL run faster I'd want to remove all usages of Ramda but that would require more time than I can justify. This PR is the removal of some Ramda functions. I forgot about these commits in November but found them by happenstance.

I used Ramda's own set of tests to make sure my helper functions are equivalent to Ramda's in function. We don't need all the functionality but I didn't bother picking and choosing.