### PR TITLE
Include TypeScript sources for source maps

### DIFF
--- a/packages/yavl-hooks/package.json
+++ b/packages/yavl-hooks/package.json
@@ -45,7 +45,8 @@
     "typescript": "^5.1.3"
   },
   "files": [
-    "dist/*"
+    "dist/*",
+    "src/*"
   ],
   "jest": {
     "preset": "ts-jest",

--- a/packages/yavl/package.json
+++ b/packages/yavl/package.json
@@ -38,7 +38,8 @@
     "validate"
   ],
   "files": [
-    "dist/*"
+    "dist/*",
+    "src/*"
   ],
   "jest": {
     "preset": "ts-jest",


### PR DESCRIPTION
Include TypeScript sources in published packages. This allows source mapping to function properly as the referenced files exists in consumers of yavl.

The generated map files look like this:

```
{"version":3,"file":"index.js","sourceRoot":"","sources":["../src/index.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;AAAA,0CAAwB"}
```

The sources don't actually exist when consuming the packages via NPM.