### PR TITLE
Replace looped copy operations in Array reduce with more optimised solutions

### DIFF
--- a/packages/yavl/src/builder/passive.ts
+++ b/packages/yavl/src/builder/passive.ts
@@ -22,13 +22,7 @@ export const passive = <T>(dependencies: T): T => {
     return dependencies.map(dependency => passive(dependency)) as T;
   }
   if (typeof dependencies === 'object' && dependencies !== null) {
-    return Object.entries(dependencies).reduce(
-      (acc, [key, value]) => ({
-        ...acc,
-        [key]: passive(value),
-      }),
-      {} as T,
-    );
+    return Object.fromEntries(Object.entries(dependencies).map(([key, value]) => [key, passive(value)])) as T;
   }
   return dependencies;
 };

--- a/packages/yavl/src/subscribeToAnnotations.ts
+++ b/packages/yavl/src/subscribeToAnnotations.ts
@@ -28,24 +28,22 @@ interface SubscribeToAnnotations {
 const getInitialValue = (
   context: ModelValidationContext<any, any, any>,
   { pathPrefix, annotations }: AnnotationsSubscriptionFilters,
-): AnnotationsSubscriptionValue => {
-  return Object.entries(context.resolvedAnnotations.current).reduce(
-    (acc: AnnotationsSubscriptionValue, [path, annotationData]) => {
+): AnnotationsSubscriptionValue =>
+  Object.fromEntries(
+    Object.entries(context.resolvedAnnotations.current).flatMap(([path, annotationData]) => {
       if (pathPrefix !== undefined && !path.startsWith(pathPrefix)) {
-        return acc;
+        return [];
       }
 
       const filteredAnnotationData = annotations ? pick(annotations, annotationData) : annotationData;
 
       if (isEmpty(filteredAnnotationData)) {
-        return acc;
+        return [];
       }
 
-      return { ...acc, [path]: filteredAnnotationData };
-    },
-    {},
+      return [[path, filteredAnnotationData]];
+    }),
   );
-};
 
 export const subscribeToAnnotations: SubscribeToAnnotations = (
   context: ModelValidationContext<any, any, any>,


### PR DESCRIPTION
I did a text search for `reduce` and found these two cases of copying an accumulator object in a loop.

This PR replaces the reduce expressions with functionally equivalent linear time expressions.

I don't expect any noticeable benefits, but I thought I might as well pick the low-hanging fruit.