### PR TITLE
Fix null-safety regression from R.pluck removal

### DIFF
--- a/packages/yavl/src/validate/resolveDependency.spec.ts
+++ b/packages/yavl/src/validate/resolveDependency.spec.ts
@@ -1,3 +1,4 @@
+import { createValidationContext, Model, model, ModelValidationContext, updateModel } from '../../src';
 import { getMockProcessingContext } from '../../tests/helpers/getMockProcessingContext';
 import resolveDependency from './resolveDependency';
 
@@ -309,6 +310,94 @@ describe('resolveDependency', () => {
       ).toThrowErrorMatchingInlineSnapshot(
         `"Trying to focus current path of array failed; current focus is not supported for external data"`,
       );
+    });
+  });
+
+  /**
+   * These tests were AI gen but tried to keep them as human friendly as possible
+   */
+  describe('when array contains null or undefined items', () => {
+    let validationContext: ModelValidationContext<any> | undefined;
+
+    const testIncrementalValidate = <T>(testModel: Model<T>, data: T) => {
+      if (!validationContext) {
+        validationContext = createValidationContext(testModel);
+      }
+      updateModel(validationContext, data);
+    };
+
+    beforeEach(() => {
+      validationContext = undefined;
+    });
+
+    type TestModel = {
+      list: ({ name: string } | null | undefined)[];
+    };
+
+    it('should resolve array.all field dependency without crashing', () => {
+      const validator = jest.fn();
+
+      const testModel = model<TestModel>((root, model) => [
+        model.field(root, 'list', _list => [
+          model.validate(model.passive(root), model.dep(root, 'list', model.array.all, 'name'), validator),
+        ]),
+      ]);
+
+      const data: TestModel = {
+        list: [{ name: 'Alice' }, null, undefined, { name: 'Diana' }],
+      };
+
+      testIncrementalValidate(testModel, data);
+
+      expect(validator).toHaveBeenCalledWith(data, ['Alice', undefined, undefined, 'Diana'], data, undefined);
+    });
+
+    it('should resolve nested array.all dependency with null items', () => {
+      type NestedModel = {
+        groups: ({ values: ({ score: number } | null | undefined)[] } | null)[];
+      };
+
+      const validator = jest.fn();
+
+      const testModel = model<NestedModel>((root, model) => [
+        model.validate(
+          model.passive(root),
+          model.dep(root, 'groups', model.array.all, 'values', model.array.all, 'score'),
+          validator,
+        ),
+      ]);
+
+      const data: NestedModel = {
+        groups: [{ values: [{ score: 10 }, null] }, null, { values: [undefined, { score: 40 }] }],
+      };
+
+      testIncrementalValidate(testModel, data);
+
+      expect(validator).toHaveBeenCalledWith(data, [10, undefined, undefined, undefined, 40], data, undefined);
+    });
+
+    it('should validate correctly after removing null items from the array', () => {
+      const validator = jest.fn();
+
+      const testModel = model<TestModel>((root, model) => [
+        model.field(root, 'list', _list => [
+          model.validate(model.passive(root), model.dep(root, 'list', model.array.all, 'name'), validator),
+        ]),
+      ]);
+
+      const initialData: TestModel = {
+        list: [{ name: 'Alice' }, null, { name: 'Charlie' }],
+      };
+      testIncrementalValidate(testModel, initialData);
+
+      jest.clearAllMocks();
+
+      const updatedData: TestModel = {
+        list: [{ name: 'Alice' }, { name: 'Charlie' }],
+      };
+      testIncrementalValidate(testModel, updatedData);
+
+      expect(validator).toHaveBeenCalledWith(updatedData, ['Alice', 'Charlie'], updatedData, undefined);
     });
   });
 });

--- a/packages/yavl/src/validate/resolveDependency.ts
+++ b/packages/yavl/src/validate/resolveDependency.ts
@@ -50,7 +50,7 @@ const resolveDependency = <Data, ExternalData, ErrorType>(
 
           return {
             ...acc,
-            data: data.map((item: any) => item[pathPart.name]),
+            data: data.map((item: any) => item?.[pathPart.name]),
             paths: paths.map(path => path.concat(pathPart.name)),
           };
         }
@@ -99,7 +99,7 @@ const resolveDependency = <Data, ExternalData, ErrorType>(
             return {
               ...acc,
               // the data we pick from is already filtered, so here we use the index as is, not the original one
-              data: data.map((item: any) => item[pathPart.index]),
+              data: data.map((item: any) => item?.[pathPart.index]),
               paths: indexedPaths,
               isFocusedOnSinglePath: false,
             };
@@ -128,7 +128,9 @@ const resolveDependency = <Data, ExternalData, ErrorType>(
 
           return {
             ...acc,
-            data: isFocusedOnSinglePath ? data?.[currentIndex] : (data as any[]).map((item: any) => item[currentIndex]),
+            data: isFocusedOnSinglePath
+              ? data?.[currentIndex]
+              : (data as any[]).map((item: any) => item?.[currentIndex]),
             paths: paths.map(path => path.concat(currentIndex)),
           };
         } else {

--- a/packages/yavl/tests/arrays.spec.ts
+++ b/packages/yavl/tests/arrays.spec.ts
@@ -398,4 +398,79 @@ describe('arrays', () => {
       expect(getValidationErrors(validationContext!)).toEqual(undefined);
     });
   });
+
+  /**
+   * These tests were AI gen but tried to keep them as human friendly as possible
+   */
+  describe('when array contains null or undefined items', () => {
+    type TestModel = {
+      list: ({ name: string } | null | undefined)[];
+    };
+
+    it('should resolve array.all field dependency without crashing', () => {
+      const validator = jest.fn();
+
+      const testModel = model<TestModel>((root, model) => [
+        model.field(root, 'list', _list => [
+          model.validate(model.passive(root), model.dep(root, 'list', model.array.all, 'name'), validator),
+        ]),
+      ]);
+
+      const data: TestModel = {
+        list: [{ name: 'Alice' }, null, undefined, { name: 'Diana' }],
+      };
+
+      testIncrementalValidate(testModel, data);
+
+      expect(validator).toHaveBeenCalledWith(data, ['Alice', undefined, undefined, 'Diana'], data, undefined);
+    });
+
+    it('should resolve nested array.all dependency with null items', () => {
+      type NestedModel = {
+        groups: ({ values: ({ score: number } | null | undefined)[] } | null)[];
+      };
+
+      const validator = jest.fn();
+
+      const testModel = model<NestedModel>((root, model) => [
+        model.validate(
+          model.passive(root),
+          model.dep(root, 'groups', model.array.all, 'values', model.array.all, 'score'),
+          validator,
+        ),
+      ]);
+
+      const data: NestedModel = {
+        groups: [{ values: [{ score: 10 }, null] }, null, { values: [undefined, { score: 40 }] }],
+      };
+
+      testIncrementalValidate(testModel, data);
+
+      expect(validator).toHaveBeenCalledWith(data, [10, undefined, undefined, undefined, 40], data, undefined);
+    });
+
+    it('should validate correctly after removing null items from the array', () => {
+      const validator = jest.fn();
+
+      const testModel = model<TestModel>((root, model) => [
+        model.field(root, 'list', _list => [
+          model.validate(model.passive(root), model.dep(root, 'list', model.array.all, 'name'), validator),
+        ]),
+      ]);
+
+      const initialData: TestModel = {
+        list: [{ name: 'Alice' }, null, { name: 'Charlie' }],
+      };
+      testIncrementalValidate(testModel, initialData);
+
+      jest.clearAllMocks();
+
+      const updatedData: TestModel = {
+        list: [{ name: 'Alice' }, { name: 'Charlie' }],
+      };
+      testIncrementalValidate(testModel, updatedData);
+
+      expect(validator).toHaveBeenCalledWith(updatedData, ['Alice', 'Charlie'], updatedData, undefined);
+    });
+  });
 });


### PR DESCRIPTION
**Summary:**

Old ramda implementation was handling cases when there was undefined when trying to resolve dependencies. With the new ramda-free implementation we lost that capability and the updateModels function was throwing.

🤖 _Extended AI explanation  :_

### Problem

During the Ramda removal effort, `R.pluck(key, array)` was replaced with `data.map((item) => item[key])` in three places within `resolveDependency.ts`. This introduced a regression: `R.pluck` gracefully returns `undefined` for `null`/`undefined` array elements, while direct property access (`item[key]`) throws a `TypeError`.

Arrays containing `null` or `undefined` items (e.g., from cross-clone/Unity transform helpers) crash when traversed with `item[key]` instead of `item?.[key]`.

### Fix

Added optional chaining at all three former `R.pluck` call sites in `packages/yavl/src/validate/resolveDependency.ts`:

| Location | Context | Change |
|---|---|---|
| Line 53 | Field access in multi-path mode | `item[pathPart.name]` → `item?.[pathPart.name]` |
| Line 102 | Index access in multi-path mode | `item[pathPart.index]` → `item?.[pathPart.index]` |
| Line 131 | Current-index access in multi-path mode | `item[currentIndex]` → `item?.[currentIndex]` |

### Tests

- 3 unit tests in `resolveDependency.spec.ts` using the model DSL
- 3 integration tests in `arrays.spec.ts` covering the same scenarios through the full validation stack

### Audit of other Ramda replacements

'All other Ramda replacements (`R.last`, `R.flatten`, `R.equals`, `R.path`, `R.assocPath`, `R.hasPath`, `R.is`, `R.unnest`, etc.) were audited and confirmed safe. The only theoretical gap is `deepEqual` not handling `Date`/`RegExp`/`Map`/`Set`, but these types are not used in yavl's form validation domain.