### PR TITLE
Fix: remove ramda from yavl-hooks

### DIFF
--- a/packages/yavl-hooks/package.json
+++ b/packages/yavl-hooks/package.json
@@ -22,8 +22,7 @@
     "typescript": ">=4 <6"
   },
   "dependencies": {
-    "@smartlyio/yavl": "^7.2.2",
-    "ramda": "^0.28.0"
+    "@smartlyio/yavl": "^7.2.2"
   },
   "keywords": [
     "typescript",

--- a/packages/yavl-hooks/src/hooks/useFieldsAnnotation.ts
+++ b/packages/yavl-hooks/src/hooks/useFieldsAnnotation.ts
@@ -1,4 +1,3 @@
-import * as R from 'ramda';
 import { ModelValidationContext, Annotation, getAnnotationValue } from '@smartlyio/yavl';
 import { useAnnotations } from './useAnnotations';
 import { useMemo } from 'react';
@@ -33,7 +32,12 @@ export const useFieldsAnnotation: UseFieldsAnnotation = <T>(
     ),
   );
 
-  const fieldAnnotations = R.mapObjIndexed(data => getAnnotationValue(data, annotation), annotations);
+  const fieldAnnotations: Record<string, T> = {};
+  for (const key in annotations) {
+    if (Object.prototype.hasOwnProperty.call(annotations, key)) {
+      fieldAnnotations[key] = getAnnotationValue(annotations[key], annotation);
+    }
+  }
 
   return fieldAnnotations;
 };

--- a/packages/yavl-hooks/src/hooks/useFieldsWithAnnotation.ts
+++ b/packages/yavl-hooks/src/hooks/useFieldsWithAnnotation.ts
@@ -1,5 +1,4 @@
-import * as R from 'ramda';
-import { ModelValidationContext, Annotation, getAnnotationValue } from '@smartlyio/yavl';
+import { ModelValidationContext, Annotation, getAnnotationValue, deepEqual } from '@smartlyio/yavl';
 import { useAnnotations } from './useAnnotations';
 import { useMemo } from 'react';
 import { useMemoizedValue } from './useMemoizedValue';
@@ -49,7 +48,7 @@ export const useFieldsWithAnnotation: UseFieldsWithAnnotation = <T>(
          */
         memoizedFilters === undefined ||
         !('value' in memoizedFilters) ||
-        R.equals(memoizedFilters.value, getAnnotationValue(fieldAnnotations, annotation))
+        deepEqual(memoizedFilters.value, getAnnotationValue(fieldAnnotations, annotation))
           ? [field]
           : [],
       ),

--- a/packages/yavl-hooks/src/hooks/useMemoizedValue.ts
+++ b/packages/yavl-hooks/src/hooks/useMemoizedValue.ts
@@ -1,10 +1,10 @@
-import * as R from 'ramda';
+import { deepEqual } from '@smartlyio/yavl';
 import { useRef } from 'react';
 
 export const useMemoizedValue = <T>(value: T): T => {
   const memoizedValueRef = useRef(value);
 
-  if (value !== memoizedValueRef.current && !R.equals(value, memoizedValueRef.current)) {
+  if (value !== memoizedValueRef.current && !deepEqual(value, memoizedValueRef.current)) {
     memoizedValueRef.current = value;
   }
 

--- a/packages/yavl/src/index.ts
+++ b/packages/yavl/src/index.ts
@@ -20,6 +20,7 @@ export { getAnnotationValue } from './getAnnotationValue';
 export { subscribeToAnnotations } from './subscribeToAnnotations';
 export { default as isModelContext } from './utils/isModelContext';
 export { noValue } from './types';
+export { deepEqual } from './utils/deepEqual';
 
 export type WhenFn<If = never, Else = never, ErrorType = string> = (
   ifFn: [If] extends [never] ? ModelDefinitionFnWithNoArg<ErrorType> : ModelDefinitionFn<If, ErrorType>,


### PR DESCRIPTION
Let's clear up the last bits of Ramda from yavl now in the hooks package.