### PR TITLE
Feat: skip full-tree diff when caller knows which paths changed

### DIFF
--- a/packages/yavl/src/index.ts
+++ b/packages/yavl/src/index.ts
@@ -53,6 +53,7 @@ export type {
   NoValue,
 } from './types';
 export type { ModelValidationContext, ModelValidationErrors, CompareFn } from './validate/types';
+export type { UpdateModelOptions } from './validate/updateModel';
 export type { FieldFn } from './builder/field';
 export type { ArrayFn } from './builder/array';
 export type { RequiredFn } from './builder/required';

--- a/packages/yavl/src/index.ts
+++ b/packages/yavl/src/index.ts
@@ -53,7 +53,7 @@ export type {
   NoValue,
 } from './types';
 export type { ModelValidationContext, ModelValidationErrors, CompareFn } from './validate/types';
-export type { UpdateModelOptions } from './validate/updateModel';
+export type { ChangedPaths } from './validate/updateModel';
 export type { FieldFn } from './builder/field';
 export type { ArrayFn } from './builder/array';
 export type { RequiredFn } from './builder/required';

--- a/packages/yavl/src/validate/expandChangedPaths.spec.ts
+++ b/packages/yavl/src/validate/expandChangedPaths.spec.ts
@@ -4,49 +4,49 @@ import { FieldsWithDependencies } from '../types';
 describe('expandChangedPaths', () => {
   const fieldsWithDependencies: FieldsWithDependencies = {
     'internal:': { hasDependencies: { computedValues: true, conditions: false, validations: false } },
-    'internal:campaigns': { hasDependencies: { computedValues: true, conditions: false, validations: false } },
-    'internal:campaigns[]': { hasDependencies: { computedValues: false, conditions: false, validations: true } },
-    'internal:campaigns[].name': { hasDependencies: { computedValues: true, conditions: false, validations: true } },
-    'internal:campaigns[].budget': { hasDependencies: { computedValues: false, conditions: true, validations: true } },
-    'internal:settings': { hasDependencies: { computedValues: false, conditions: false, validations: true } },
-    'internal:settings.theme': { hasDependencies: { computedValues: false, conditions: false, validations: true } },
+    'internal:users': { hasDependencies: { computedValues: true, conditions: false, validations: false } },
+    'internal:users[]': { hasDependencies: { computedValues: false, conditions: false, validations: true } },
+    'internal:users[].name': { hasDependencies: { computedValues: true, conditions: false, validations: true } },
+    'internal:users[].age': { hasDependencies: { computedValues: false, conditions: true, validations: true } },
+    'internal:preferences': { hasDependencies: { computedValues: false, conditions: false, validations: true } },
+    'internal:preferences.locale': { hasDependencies: { computedValues: false, conditions: false, validations: true } },
   };
 
   it('should expand a leaf path to all ancestor prefixes that exist in fieldsWithDependencies', () => {
-    const result = expandChangedPaths([['campaigns', 0, 'name']], fieldsWithDependencies, false, 'validations');
+    const result = expandChangedPaths([['users', 0, 'name']], fieldsWithDependencies, false, 'validations');
 
     const pathStrings = result.changedFields.map(p => p.join('.'));
     expect(pathStrings).toContain('');
-    expect(pathStrings).toContain('campaigns');
-    expect(pathStrings).toContain('campaigns.0');
-    expect(pathStrings).toContain('campaigns.0.name');
+    expect(pathStrings).toContain('users');
+    expect(pathStrings).toContain('users.0');
+    expect(pathStrings).toContain('users.0.name');
   });
 
   it('should filter by changesFor when includeFieldsWithoutDependencies is false', () => {
-    const result = expandChangedPaths([['campaigns', 0, 'name']], fieldsWithDependencies, false, 'annotations');
+    const result = expandChangedPaths([['users', 0, 'name']], fieldsWithDependencies, false, 'annotations');
 
     const pathStrings = result.changedFields.map(p => p.join('.'));
     expect(pathStrings).toContain('');
-    expect(pathStrings).toContain('campaigns');
-    expect(pathStrings).toContain('campaigns.0.name');
-    expect(pathStrings).not.toContain('campaigns.0');
+    expect(pathStrings).toContain('users');
+    expect(pathStrings).toContain('users.0.name');
+    expect(pathStrings).not.toContain('users.0');
   });
 
   it('should include all fields when includeFieldsWithoutDependencies is true', () => {
-    const result = expandChangedPaths([['campaigns', 0, 'name']], fieldsWithDependencies, true, 'annotations');
+    const result = expandChangedPaths([['users', 0, 'name']], fieldsWithDependencies, true, 'annotations');
 
     const pathStrings = result.changedFields.map(p => p.join('.'));
     expect(pathStrings).toContain('');
-    expect(pathStrings).toContain('campaigns');
-    expect(pathStrings).toContain('campaigns.0');
-    expect(pathStrings).toContain('campaigns.0.name');
+    expect(pathStrings).toContain('users');
+    expect(pathStrings).toContain('users.0');
+    expect(pathStrings).toContain('users.0.name');
   });
 
   it('should deduplicate when multiple leaf paths share ancestor prefixes', () => {
     const result = expandChangedPaths(
       [
-        ['campaigns', 0, 'name'],
-        ['campaigns', 0, 'budget'],
+        ['users', 0, 'name'],
+        ['users', 0, 'age'],
       ],
       fieldsWithDependencies,
       true,
@@ -56,8 +56,8 @@ describe('expandChangedPaths', () => {
     const pathStrings = result.changedFields.map(p => p.join('.'));
     const rootOccurrences = pathStrings.filter(p => p === '').length;
     expect(rootOccurrences).toBe(1);
-    expect(pathStrings).toContain('campaigns.0.name');
-    expect(pathStrings).toContain('campaigns.0.budget');
+    expect(pathStrings).toContain('users.0.name');
+    expect(pathStrings).toContain('users.0.age');
   });
 
   it('should skip paths not in fieldsWithDependencies (except root if registered)', () => {
@@ -70,7 +70,7 @@ describe('expandChangedPaths', () => {
 
   it('should return no results when even root is not registered', () => {
     const sparseFieldsWithDependencies: FieldsWithDependencies = {
-      'internal:campaigns[].name': {
+      'internal:users[].name': {
         hasDependencies: { computedValues: true, conditions: false, validations: false },
       },
     };
@@ -81,7 +81,7 @@ describe('expandChangedPaths', () => {
   });
 
   it('should return empty arraysWithChangedLength', () => {
-    const result = expandChangedPaths([['campaigns', 0, 'name']], fieldsWithDependencies, true, 'validations');
+    const result = expandChangedPaths([['users', 0, 'name']], fieldsWithDependencies, true, 'validations');
 
     expect(result.arraysWithChangedLength).toHaveLength(0);
   });
@@ -94,50 +94,50 @@ describe('expandChangedPaths', () => {
   });
 
   it('should handle paths to fields outside arrays', () => {
-    const result = expandChangedPaths([['settings', 'theme']], fieldsWithDependencies, true, 'validations');
+    const result = expandChangedPaths([['preferences', 'locale']], fieldsWithDependencies, true, 'validations');
 
     const pathStrings = result.changedFields.map(p => p.join('.'));
-    expect(pathStrings).toContain('settings');
-    expect(pathStrings).toContain('settings.theme');
+    expect(pathStrings).toContain('preferences');
+    expect(pathStrings).toContain('preferences.locale');
   });
 
   it('should handle nested array paths by stripping all indices for dependency lookup', () => {
     const nestedFieldsWithDependencies: FieldsWithDependencies = {
       'internal:': { hasDependencies: { computedValues: true, conditions: false, validations: false } },
-      'internal:campaigns': { hasDependencies: { computedValues: true, conditions: false, validations: false } },
-      'internal:campaigns[]': { hasDependencies: { computedValues: false, conditions: false, validations: true } },
-      'internal:campaigns[].adGroups': {
+      'internal:teams': { hasDependencies: { computedValues: true, conditions: false, validations: false } },
+      'internal:teams[]': { hasDependencies: { computedValues: false, conditions: false, validations: true } },
+      'internal:teams[].members': {
         hasDependencies: { computedValues: true, conditions: false, validations: false },
       },
-      'internal:campaigns[].adGroups[]': {
+      'internal:teams[].members[]': {
         hasDependencies: { computedValues: false, conditions: false, validations: true },
       },
-      'internal:campaigns[].adGroups[].name': {
+      'internal:teams[].members[].name': {
         hasDependencies: { computedValues: true, conditions: false, validations: true },
       },
     };
 
     const result = expandChangedPaths(
-      [['campaigns', 2, 'adGroups', 0, 'name']],
+      [['teams', 2, 'members', 0, 'name']],
       nestedFieldsWithDependencies,
       true,
       'validations',
     );
 
     const pathStrings = result.changedFields.map(p => p.join('.'));
-    expect(pathStrings).toContain('campaigns');
-    expect(pathStrings).toContain('campaigns.2');
-    expect(pathStrings).toContain('campaigns.2.adGroups');
-    expect(pathStrings).toContain('campaigns.2.adGroups.0');
-    expect(pathStrings).toContain('campaigns.2.adGroups.0.name');
+    expect(pathStrings).toContain('teams');
+    expect(pathStrings).toContain('teams.2');
+    expect(pathStrings).toContain('teams.2.members');
+    expect(pathStrings).toContain('teams.2.members.0');
+    expect(pathStrings).toContain('teams.2.members.0.name');
   });
 
   it('should handle a single-segment path', () => {
-    const result = expandChangedPaths([['campaigns']], fieldsWithDependencies, true, 'validations');
+    const result = expandChangedPaths([['users']], fieldsWithDependencies, true, 'validations');
 
     const pathStrings = result.changedFields.map(p => p.join('.'));
     expect(pathStrings).toContain('');
-    expect(pathStrings).toContain('campaigns');
+    expect(pathStrings).toContain('users');
     expect(pathStrings).toHaveLength(2);
   });
 });

--- a/packages/yavl/src/validate/expandChangedPaths.spec.ts
+++ b/packages/yavl/src/validate/expandChangedPaths.spec.ts
@@ -1,0 +1,143 @@
+import { expandChangedPaths } from './processModelChanges';
+import { FieldsWithDependencies } from '../types';
+
+describe('expandChangedPaths', () => {
+  const fieldsWithDependencies: FieldsWithDependencies = {
+    'internal:': { hasDependencies: { computedValues: true, conditions: false, validations: false } },
+    'internal:campaigns': { hasDependencies: { computedValues: true, conditions: false, validations: false } },
+    'internal:campaigns[]': { hasDependencies: { computedValues: false, conditions: false, validations: true } },
+    'internal:campaigns[].name': { hasDependencies: { computedValues: true, conditions: false, validations: true } },
+    'internal:campaigns[].budget': { hasDependencies: { computedValues: false, conditions: true, validations: true } },
+    'internal:settings': { hasDependencies: { computedValues: false, conditions: false, validations: true } },
+    'internal:settings.theme': { hasDependencies: { computedValues: false, conditions: false, validations: true } },
+  };
+
+  it('should expand a leaf path to all ancestor prefixes that exist in fieldsWithDependencies', () => {
+    const result = expandChangedPaths([['campaigns', 0, 'name']], fieldsWithDependencies, false, 'validations');
+
+    const pathStrings = result.changedFields.map(p => p.join('.'));
+    expect(pathStrings).toContain('');
+    expect(pathStrings).toContain('campaigns');
+    expect(pathStrings).toContain('campaigns.0');
+    expect(pathStrings).toContain('campaigns.0.name');
+  });
+
+  it('should filter by changesFor when includeFieldsWithoutDependencies is false', () => {
+    const result = expandChangedPaths([['campaigns', 0, 'name']], fieldsWithDependencies, false, 'annotations');
+
+    const pathStrings = result.changedFields.map(p => p.join('.'));
+    expect(pathStrings).toContain('');
+    expect(pathStrings).toContain('campaigns');
+    expect(pathStrings).toContain('campaigns.0.name');
+    expect(pathStrings).not.toContain('campaigns.0');
+  });
+
+  it('should include all fields when includeFieldsWithoutDependencies is true', () => {
+    const result = expandChangedPaths([['campaigns', 0, 'name']], fieldsWithDependencies, true, 'annotations');
+
+    const pathStrings = result.changedFields.map(p => p.join('.'));
+    expect(pathStrings).toContain('');
+    expect(pathStrings).toContain('campaigns');
+    expect(pathStrings).toContain('campaigns.0');
+    expect(pathStrings).toContain('campaigns.0.name');
+  });
+
+  it('should deduplicate when multiple leaf paths share ancestor prefixes', () => {
+    const result = expandChangedPaths(
+      [
+        ['campaigns', 0, 'name'],
+        ['campaigns', 0, 'budget'],
+      ],
+      fieldsWithDependencies,
+      true,
+      'validations',
+    );
+
+    const pathStrings = result.changedFields.map(p => p.join('.'));
+    const rootOccurrences = pathStrings.filter(p => p === '').length;
+    expect(rootOccurrences).toBe(1);
+    expect(pathStrings).toContain('campaigns.0.name');
+    expect(pathStrings).toContain('campaigns.0.budget');
+  });
+
+  it('should skip paths not in fieldsWithDependencies (except root if registered)', () => {
+    const result = expandChangedPaths([['unknown', 'field']], fieldsWithDependencies, true, 'validations');
+
+    const pathStrings = result.changedFields.map(p => p.join('.'));
+    expect(pathStrings).not.toContain('unknown');
+    expect(pathStrings).not.toContain('unknown.field');
+  });
+
+  it('should return no results when even root is not registered', () => {
+    const sparseFieldsWithDependencies: FieldsWithDependencies = {
+      'internal:campaigns[].name': {
+        hasDependencies: { computedValues: true, conditions: false, validations: false },
+      },
+    };
+
+    const result = expandChangedPaths([['unknown', 'field']], sparseFieldsWithDependencies, true, 'validations');
+
+    expect(result.changedFields).toHaveLength(0);
+  });
+
+  it('should return empty arraysWithChangedLength', () => {
+    const result = expandChangedPaths([['campaigns', 0, 'name']], fieldsWithDependencies, true, 'validations');
+
+    expect(result.arraysWithChangedLength).toHaveLength(0);
+  });
+
+  it('should handle an empty changedPaths array', () => {
+    const result = expandChangedPaths([], fieldsWithDependencies, true, 'validations');
+
+    expect(result.changedFields).toHaveLength(0);
+    expect(result.arraysWithChangedLength).toHaveLength(0);
+  });
+
+  it('should handle paths to fields outside arrays', () => {
+    const result = expandChangedPaths([['settings', 'theme']], fieldsWithDependencies, true, 'validations');
+
+    const pathStrings = result.changedFields.map(p => p.join('.'));
+    expect(pathStrings).toContain('settings');
+    expect(pathStrings).toContain('settings.theme');
+  });
+
+  it('should handle nested array paths by stripping all indices for dependency lookup', () => {
+    const nestedFieldsWithDependencies: FieldsWithDependencies = {
+      'internal:': { hasDependencies: { computedValues: true, conditions: false, validations: false } },
+      'internal:campaigns': { hasDependencies: { computedValues: true, conditions: false, validations: false } },
+      'internal:campaigns[]': { hasDependencies: { computedValues: false, conditions: false, validations: true } },
+      'internal:campaigns[].adGroups': {
+        hasDependencies: { computedValues: true, conditions: false, validations: false },
+      },
+      'internal:campaigns[].adGroups[]': {
+        hasDependencies: { computedValues: false, conditions: false, validations: true },
+      },
+      'internal:campaigns[].adGroups[].name': {
+        hasDependencies: { computedValues: true, conditions: false, validations: true },
+      },
+    };
+
+    const result = expandChangedPaths(
+      [['campaigns', 2, 'adGroups', 0, 'name']],
+      nestedFieldsWithDependencies,
+      true,
+      'validations',
+    );
+
+    const pathStrings = result.changedFields.map(p => p.join('.'));
+    expect(pathStrings).toContain('campaigns');
+    expect(pathStrings).toContain('campaigns.2');
+    expect(pathStrings).toContain('campaigns.2.adGroups');
+    expect(pathStrings).toContain('campaigns.2.adGroups.0');
+    expect(pathStrings).toContain('campaigns.2.adGroups.0.name');
+  });
+
+  it('should handle a single-segment path', () => {
+    const result = expandChangedPaths([['campaigns']], fieldsWithDependencies, true, 'validations');
+
+    const pathStrings = result.changedFields.map(p => p.join('.'));
+    expect(pathStrings).toContain('');
+    expect(pathStrings).toContain('campaigns');
+    expect(pathStrings).toHaveLength(2);
+  });
+});

--- a/packages/yavl/src/validate/getChangedData.ts
+++ b/packages/yavl/src/validate/getChangedData.ts
@@ -13,7 +13,7 @@ export type GetChangedDataResult = {
   arraysWithChangedLength: ListOfFields;
 };
 
-const shouldIncludeField = (
+export const shouldIncludeField = (
   changesFor: 'annotations' | 'conditions' | 'validations',
   hasDependencies: HasDependenciesInfo,
 ) => {

--- a/packages/yavl/src/validate/processModelChanges.ts
+++ b/packages/yavl/src/validate/processModelChanges.ts
@@ -1,4 +1,4 @@
-import getChangedData from './getChangedData';
+import getChangedData, { shouldIncludeField } from './getChangedData';
 import { createProcessingContext, updateContextDataAndChangedAnnotations } from './processModelHelpers';
 import processChangedFields from './processChangedFields';
 import { processModelRecursively } from './processModelRecursively';
@@ -11,17 +11,61 @@ import {
   UnprocessedValidationsForCondition,
 } from './types';
 import { updateModelCaches } from './updateModelCaches';
-import { Annotation, FieldDependencyEntry } from '../types';
+import { Annotation, FieldDependencyEntry, FieldsWithDependencies } from '../types';
 import getDependencyPathPermutations from '../utils/getDependencyPathPermutations';
 import { strPathToArray } from '../utils/strPathToArray';
 import rejectUndefinedValues from '../utils/rejectUndefinedValues';
 import { processChangedAnnotations } from './processChangedAnnotations';
 import { processArraysWithChangedLength } from './processArraysWithChangedLength';
 import dataPathToStr from '../utils/dataPathToStr';
+import { getPathWithoutIndices } from '../utils/getPathWithoutIndices';
+import { GetChangedDataResult } from './getChangedData';
+
+type PathToField = ReadonlyArray<string | number>;
 
 type Definitions = 'annotations' | 'conditions' | 'validations';
 
 type ChangedPath = ReadonlyArray<string | number>;
+
+/**
+ * Given a set of leaf paths known to have changed, expand each to all ancestor
+ * prefixes and filter by fieldsWithDependencies. This replaces the full-tree
+ * diff of getChangedData when the caller already knows which paths changed.
+ */
+export const expandChangedPaths = (
+  leafPaths: ReadonlyArray<PathToField>,
+  fieldsWithDependencies: FieldsWithDependencies,
+  includeFieldsWithoutDependencies: boolean,
+  changesFor: 'annotations' | 'conditions' | 'validations',
+): GetChangedDataResult => {
+  const changedFields: Array<PathToField> = [];
+  const seen = new Set<string>();
+
+  for (const leafPath of leafPaths) {
+    for (let i = 0; i <= leafPath.length; i++) {
+      const prefix = leafPath.slice(0, i);
+      const pathStr = dataPathToStr(prefix);
+
+      if (seen.has(pathStr)) {
+        continue;
+      }
+      seen.add(pathStr);
+
+      const strippedPath = getPathWithoutIndices(pathStr);
+      const depInfo = fieldsWithDependencies[`internal:${strippedPath}`];
+
+      if (!depInfo) {
+        continue;
+      }
+
+      if (includeFieldsWithoutDependencies || shouldIncludeField(changesFor, depInfo.hasDependencies)) {
+        changedFields.push(prefix);
+      }
+    }
+  }
+
+  return { changedFields, arraysWithChangedLength: [] };
+};
 type ChangedData = Set<ChangedPath>;
 type ChangedDataByPathLength = Map<number, Set<string>>;
 
@@ -280,6 +324,7 @@ export const processModelChanges = <Data, ExternalData, ErrorType>(
   data: Data,
   externalData: ExternalData,
   isEqualFn: CompareFn,
+  changedPaths?: ReadonlyArray<PathToField>,
 ): ProcessingContext<Data, ExternalData, ErrorType> => {
   const previousDataAtStartOfUpdate = isInitialValidation ? undefined : context.previousData;
   const previousExternalDataAtStartOfUpdate = isInitialValidation ? undefined : context.previousExternalData;
@@ -392,15 +437,24 @@ export const processModelChanges = <Data, ExternalData, ErrorType>(
       );
     }
 
-    const { changedFields: changedData, arraysWithChangedLength } = getChangedData({
-      newData: data,
-      oldData: context.previousData,
-      type: 'internal',
-      fieldsWithDependencies: context.model.fieldsWithDependencies,
-      includeFieldsWithoutDependencies,
-      changesFor: stopAfter,
-      isEqualFn,
-    });
+    const useHint = isFirstPass && changedPaths !== undefined && changedPaths.length > 0;
+
+    const { changedFields: changedData, arraysWithChangedLength } = useHint
+      ? expandChangedPaths(
+          changedPaths,
+          context.model.fieldsWithDependencies,
+          includeFieldsWithoutDependencies,
+          stopAfter,
+        )
+      : getChangedData({
+          newData: data,
+          oldData: context.previousData,
+          type: 'internal',
+          fieldsWithDependencies: context.model.fieldsWithDependencies,
+          includeFieldsWithoutDependencies,
+          changesFor: stopAfter,
+          isEqualFn,
+        });
 
     changedData.forEach(changedField => {
       const fieldStr = dataPathToStr(changedField);

--- a/packages/yavl/src/validate/updateModel.ts
+++ b/packages/yavl/src/validate/updateModel.ts
@@ -4,30 +4,25 @@ import notifySubscribers from './notifySubscribers';
 import { processModelChanges } from './processModelChanges';
 import { processInitialModel } from './processInitialModel';
 
-type PathToField = ReadonlyArray<string | number>;
-
-export interface UpdateModelOptions {
-  isEqualFn?: CompareFn;
-  changedPaths?: ReadonlyArray<PathToField>;
-}
+export type ChangedPaths = ReadonlyArray<ReadonlyArray<string | number>>;
 
 interface UpdateModelFn {
   <FormData, ExternalData = undefined, ErrorType = string>(
     context: ModelValidationContext<FormData, ExternalData, ErrorType>,
     data: NoInfer<FormData>,
     externalData?: NoInfer<ExternalData>,
-    isEqualFnOrOptions?: CompareFn | UpdateModelOptions,
+    isEqualFn?: CompareFn,
+    changedPaths?: ChangedPaths,
   ): void;
 }
+
 const updateModel: UpdateModelFn = <Data, ExternalData = undefined, ErrorType = string>(
   context: ModelValidationContext<Data, ExternalData, ErrorType>,
   data: Data,
   externalData?: ExternalData,
-  isEqualFnOrOptions?: CompareFn | UpdateModelOptions,
+  isEqualFn: CompareFn = Object.is,
+  changedPaths?: ChangedPaths,
 ): void => {
-  const isOptions = isEqualFnOrOptions !== undefined && typeof isEqualFnOrOptions !== 'function';
-  const isEqualFn = isOptions ? isEqualFnOrOptions.isEqualFn ?? Object.is : isEqualFnOrOptions ?? Object.is;
-  const changedPaths = isOptions ? isEqualFnOrOptions.changedPaths : undefined;
   const isInitialValidation = context.previousData === undefined;
 
   if (isInitialValidation) {

--- a/packages/yavl/src/validate/updateModel.ts
+++ b/packages/yavl/src/validate/updateModel.ts
@@ -4,20 +4,30 @@ import notifySubscribers from './notifySubscribers';
 import { processModelChanges } from './processModelChanges';
 import { processInitialModel } from './processInitialModel';
 
+type PathToField = ReadonlyArray<string | number>;
+
+export interface UpdateModelOptions {
+  isEqualFn?: CompareFn;
+  changedPaths?: ReadonlyArray<PathToField>;
+}
+
 interface UpdateModelFn {
   <FormData, ExternalData = undefined, ErrorType = string>(
     context: ModelValidationContext<FormData, ExternalData, ErrorType>,
     data: NoInfer<FormData>,
     externalData?: NoInfer<ExternalData>,
-    isEqualFn?: CompareFn,
+    isEqualFnOrOptions?: CompareFn | UpdateModelOptions,
   ): void;
 }
 const updateModel: UpdateModelFn = <Data, ExternalData = undefined, ErrorType = string>(
   context: ModelValidationContext<Data, ExternalData, ErrorType>,
   data: Data,
   externalData?: ExternalData,
-  isEqualFn: CompareFn = Object.is,
+  isEqualFnOrOptions?: CompareFn | UpdateModelOptions,
 ): void => {
+  const isOptions = isEqualFnOrOptions !== undefined && typeof isEqualFnOrOptions !== 'function';
+  const isEqualFn = isOptions ? isEqualFnOrOptions.isEqualFn ?? Object.is : isEqualFnOrOptions ?? Object.is;
+  const changedPaths = isOptions ? isEqualFnOrOptions.changedPaths : undefined;
   const isInitialValidation = context.previousData === undefined;
 
   if (isInitialValidation) {
@@ -25,12 +35,13 @@ const updateModel: UpdateModelFn = <Data, ExternalData = undefined, ErrorType = 
   } else {
     processModelChanges(
       context,
-      undefined, // no processing context from initial update
+      undefined,
       'validations',
       isInitialValidation,
       data,
       externalData,
       isEqualFn,
+      changedPaths,
     );
   }
 

--- a/packages/yavl/tests/changedPaths.spec.ts
+++ b/packages/yavl/tests/changedPaths.spec.ts
@@ -1,0 +1,353 @@
+import { createValidationContext, getModelData, model, updateModel } from '../src';
+import getValidationErrors from '../src/validate/getValidationErrors';
+
+type TestModel = {
+  campaignName: string;
+  budget: number;
+  computed?: string;
+  items: { name: string; value: number }[];
+};
+
+describe('updateModel with changedPaths', () => {
+  const initialData: TestModel = {
+    campaignName: 'test',
+    budget: 100,
+    items: [
+      { name: 'item1', value: 1 },
+      { name: 'item2', value: 2 },
+    ],
+  };
+
+  describe('with computed values', () => {
+    const testModel = model<TestModel>((root, builder) => [
+      builder.withFields(root, ['campaignName', 'budget', 'computed', 'items'], ({ campaignName, computed }) => [
+        builder.value(
+          computed,
+          builder.compute(campaignName, (name: string) => `computed:${name}`),
+        ),
+      ]),
+    ]);
+
+    it('should produce the same model data with and without changedPaths hint', () => {
+      const contextWithHint = createValidationContext(testModel);
+      const contextWithoutHint = createValidationContext(testModel);
+
+      updateModel(contextWithHint, initialData);
+      updateModel(contextWithoutHint, initialData);
+
+      const updatedData: TestModel = {
+        ...initialData,
+        campaignName: 'updated',
+      };
+
+      updateModel(contextWithHint, updatedData, undefined, {
+        changedPaths: [['campaignName']],
+      });
+
+      updateModel(contextWithoutHint, updatedData);
+
+      expect(getModelData(contextWithHint)).toEqual(getModelData(contextWithoutHint));
+    });
+
+    it('should propagate computed value changes even with changedPaths hint', () => {
+      const context = createValidationContext(testModel);
+      updateModel(context, initialData);
+
+      const updatedData: TestModel = {
+        ...initialData,
+        campaignName: 'new-name',
+      };
+
+      updateModel(context, updatedData, undefined, {
+        changedPaths: [['campaignName']],
+      });
+
+      const data = getModelData(context);
+      expect(data.computed).toBe('computed:new-name');
+    });
+  });
+
+  describe('with validations', () => {
+    const validateFn = jest.fn();
+
+    const testModel = model<TestModel>((root, builder) => [
+      builder.withFields(root, ['campaignName', 'budget', 'items'], ({ campaignName, budget }) => [
+        builder.validate(campaignName, { budget }, validateFn),
+      ]),
+    ]);
+
+    beforeEach(() => {
+      validateFn.mockClear();
+    });
+
+    it('should run validations when changedPaths hint is provided', () => {
+      const context = createValidationContext(testModel);
+      updateModel(context, initialData);
+
+      validateFn.mockClear();
+
+      const updatedData: TestModel = {
+        ...initialData,
+        campaignName: 'updated',
+      };
+
+      updateModel(context, updatedData, undefined, {
+        changedPaths: [['campaignName']],
+      });
+
+      expect(validateFn).toHaveBeenCalled();
+    });
+
+    it('should produce the same validation errors with and without hint', () => {
+      const validationError = 'name too short';
+      validateFn.mockReturnValue(validationError);
+
+      const contextWithHint = createValidationContext(testModel);
+      const contextWithoutHint = createValidationContext(testModel);
+
+      updateModel(contextWithHint, initialData);
+      updateModel(contextWithoutHint, initialData);
+
+      const updatedData: TestModel = {
+        ...initialData,
+        campaignName: 'x',
+      };
+
+      updateModel(contextWithHint, updatedData, undefined, {
+        changedPaths: [['campaignName']],
+      });
+
+      updateModel(contextWithoutHint, updatedData);
+
+      expect(getValidationErrors(contextWithHint)).toEqual(getValidationErrors(contextWithoutHint));
+    });
+  });
+
+  describe('with conditions', () => {
+    const testModel = model<TestModel>((root, builder) => [
+      builder.withFields(
+        root,
+        ['campaignName', 'budget', 'computed', 'items'],
+        ({ campaignName, budget, computed }) => [
+          builder.when(
+            campaignName,
+            (name: string) => name === 'active',
+            () => [
+              builder.value(
+                computed,
+                builder.compute(budget, (b: number) => `budget:${b}`),
+              ),
+            ],
+          ),
+        ],
+      ),
+    ]);
+
+    it('should produce the same model data with and without hint when condition triggers', () => {
+      const contextWithHint = createValidationContext(testModel);
+      const contextWithoutHint = createValidationContext(testModel);
+
+      updateModel(contextWithHint, { ...initialData, campaignName: 'inactive' });
+      updateModel(contextWithoutHint, { ...initialData, campaignName: 'inactive' });
+
+      const updatedData: TestModel = {
+        ...initialData,
+        campaignName: 'active',
+      };
+
+      updateModel(contextWithHint, updatedData, undefined, {
+        changedPaths: [['campaignName']],
+      });
+
+      updateModel(contextWithoutHint, updatedData);
+
+      expect(getModelData(contextWithHint)).toEqual(getModelData(contextWithoutHint));
+    });
+  });
+
+  describe('with array item changes', () => {
+    type ArrayModel = {
+      list: { name: string; computed?: string }[];
+    };
+
+    const testModel = model<ArrayModel>((root, builder) => [
+      builder.field(root, 'list', list => [
+        builder.array(list, item => [
+          builder.withFields(item, ['name', 'computed'], ({ name, computed }) => [
+            builder.value(
+              computed,
+              builder.compute(name, (n: string) => `upper:${n.toUpperCase()}`),
+            ),
+          ]),
+        ]),
+      ]),
+    ]);
+
+    const arrayInitialData: ArrayModel = {
+      list: [{ name: 'alice' }, { name: 'bob' }, { name: 'charlie' }],
+    };
+
+    it('should produce the same model data when changing an array item field', () => {
+      const contextWithHint = createValidationContext(testModel);
+      const contextWithoutHint = createValidationContext(testModel);
+
+      updateModel(contextWithHint, arrayInitialData);
+      updateModel(contextWithoutHint, arrayInitialData);
+
+      // use model data (which includes computed values) as the base for the next update,
+      // matching how campaign-manager feeds Yavl: always passing the latest model data back
+      const modelDataWithHint = getModelData(contextWithHint);
+      const modelDataWithoutHint = getModelData(contextWithoutHint);
+
+      const updatedForHint: ArrayModel = {
+        list: [{ ...modelDataWithHint.list[0], name: 'ALICE' }, modelDataWithHint.list[1], modelDataWithHint.list[2]],
+      };
+
+      const updatedForNoHint: ArrayModel = {
+        list: [
+          { ...modelDataWithoutHint.list[0], name: 'ALICE' },
+          modelDataWithoutHint.list[1],
+          modelDataWithoutHint.list[2],
+        ],
+      };
+
+      updateModel(contextWithHint, updatedForHint, undefined, {
+        changedPaths: [['list', 0, 'name']],
+      });
+
+      updateModel(contextWithoutHint, updatedForNoHint);
+
+      expect(getModelData(contextWithHint)).toEqual(getModelData(contextWithoutHint));
+    });
+
+    it('should update the computed value for the changed array item', () => {
+      const context = createValidationContext(testModel);
+      updateModel(context, arrayInitialData);
+
+      const modelData = getModelData(context);
+
+      const updatedData: ArrayModel = {
+        list: [{ ...modelData.list[0], name: 'updated' }, modelData.list[1], modelData.list[2]],
+      };
+
+      updateModel(context, updatedData, undefined, {
+        changedPaths: [['list', 0, 'name']],
+      });
+
+      const data = getModelData(context);
+      expect(data.list[0].computed).toBe('upper:UPDATED');
+      expect(data.list[1].computed).toBe('upper:BOB');
+      expect(data.list[2].computed).toBe('upper:CHARLIE');
+    });
+  });
+
+  describe('with multiple changedPaths', () => {
+    const testModel = model<TestModel>((root, builder) => [
+      builder.withFields(
+        root,
+        ['campaignName', 'budget', 'computed', 'items'],
+        ({ campaignName, budget, computed }) => [
+          builder.value(
+            computed,
+            builder.compute({ campaignName, budget }, ({ campaignName: n, budget: b }) => `${n}:${b}`),
+          ),
+        ],
+      ),
+    ]);
+
+    it('should handle multiple fields changing at once', () => {
+      const contextWithHint = createValidationContext(testModel);
+      const contextWithoutHint = createValidationContext(testModel);
+
+      updateModel(contextWithHint, initialData);
+      updateModel(contextWithoutHint, initialData);
+
+      const updatedData: TestModel = {
+        ...initialData,
+        campaignName: 'new-name',
+        budget: 999,
+      };
+
+      updateModel(contextWithHint, updatedData, undefined, {
+        changedPaths: [['campaignName'], ['budget']],
+      });
+
+      updateModel(contextWithoutHint, updatedData);
+
+      expect(getModelData(contextWithHint)).toEqual(getModelData(contextWithoutHint));
+      expect(getModelData(contextWithHint).computed).toBe('new-name:999');
+    });
+  });
+
+  describe('with cascading computed values across multiple passes', () => {
+    type CascadeModel = {
+      a: string;
+      b?: string;
+      c?: string;
+    };
+
+    const testModel = model<CascadeModel>((root, builder) => [
+      builder.withFields(root, ['a', 'b', 'c'], ({ a, b, c }) => [builder.value(b, a), builder.value(c, b)]),
+    ]);
+
+    it('should produce the same result with hint when computed values cascade through multiple passes', () => {
+      const contextWithHint = createValidationContext(testModel);
+      const contextWithoutHint = createValidationContext(testModel);
+
+      const cascadeInitial: CascadeModel = { a: 'start' };
+
+      updateModel(contextWithHint, cascadeInitial);
+      updateModel(contextWithoutHint, cascadeInitial);
+
+      const cascadeUpdated: CascadeModel = { a: 'changed' };
+
+      updateModel(contextWithHint, cascadeUpdated, undefined, {
+        changedPaths: [['a']],
+      });
+
+      updateModel(contextWithoutHint, cascadeUpdated);
+
+      const withHint = getModelData(contextWithHint);
+      const withoutHint = getModelData(contextWithoutHint);
+
+      expect(withHint).toEqual(withoutHint);
+      expect(withHint.b).toBe('changed');
+      expect(withHint.c).toBe('changed');
+    });
+  });
+
+  describe('backward compatibility', () => {
+    const testModel = model<TestModel>((root, builder) => [
+      builder.withFields(root, ['campaignName', 'budget', 'computed', 'items'], ({ campaignName, computed }) => [
+        builder.value(
+          computed,
+          builder.compute(campaignName, (name: string) => `computed:${name}`),
+        ),
+      ]),
+    ]);
+
+    it('should work when called with isEqualFn as a function (legacy signature)', () => {
+      const context = createValidationContext(testModel);
+      updateModel(context, initialData, undefined, Object.is);
+
+      const data = getModelData(context);
+      expect(data.computed).toBe('computed:test');
+    });
+
+    it('should work when called without 4th argument', () => {
+      const context = createValidationContext(testModel);
+      updateModel(context, initialData);
+
+      const data = getModelData(context);
+      expect(data.computed).toBe('computed:test');
+    });
+
+    it('should work when called with options object', () => {
+      const context = createValidationContext(testModel);
+      updateModel(context, initialData, undefined, { isEqualFn: Object.is });
+
+      const data = getModelData(context);
+      expect(data.computed).toBe('computed:test');
+    });
+  });
+});

--- a/packages/yavl/tests/changedPaths.spec.ts
+++ b/packages/yavl/tests/changedPaths.spec.ts
@@ -1,29 +1,29 @@
 import { createValidationContext, getModelData, model, updateModel } from '../src';
 import getValidationErrors from '../src/validate/getValidationErrors';
 
-type TestModel = {
-  campaignName: string;
-  budget: number;
-  computed?: string;
-  items: { name: string; value: number }[];
+type UserProfile = {
+  username: string;
+  age: number;
+  displayName?: string;
+  tags: { label: string; value: number }[];
 };
 
 describe('updateModel with changedPaths', () => {
-  const initialData: TestModel = {
-    campaignName: 'test',
-    budget: 100,
-    items: [
-      { name: 'item1', value: 1 },
-      { name: 'item2', value: 2 },
+  const initialData: UserProfile = {
+    username: 'alice',
+    age: 30,
+    tags: [
+      { label: 'admin', value: 1 },
+      { label: 'editor', value: 2 },
     ],
   };
 
   describe('with computed values', () => {
-    const testModel = model<TestModel>((root, builder) => [
-      builder.withFields(root, ['campaignName', 'budget', 'computed', 'items'], ({ campaignName, computed }) => [
+    const testModel = model<UserProfile>((root, builder) => [
+      builder.withFields(root, ['username', 'age', 'displayName', 'tags'], ({ username, displayName }) => [
         builder.value(
-          computed,
-          builder.compute(campaignName, (name: string) => `computed:${name}`),
+          displayName,
+          builder.compute(username, (name: string) => `@${name}`),
         ),
       ]),
     ]);
@@ -35,14 +35,12 @@ describe('updateModel with changedPaths', () => {
       updateModel(contextWithHint, initialData);
       updateModel(contextWithoutHint, initialData);
 
-      const updatedData: TestModel = {
+      const updatedData: UserProfile = {
         ...initialData,
-        campaignName: 'updated',
+        username: 'bob',
       };
 
-      updateModel(contextWithHint, updatedData, undefined, {
-        changedPaths: [['campaignName']],
-      });
+      updateModel(contextWithHint, updatedData, undefined, undefined, [['username']]);
 
       updateModel(contextWithoutHint, updatedData);
 
@@ -53,26 +51,24 @@ describe('updateModel with changedPaths', () => {
       const context = createValidationContext(testModel);
       updateModel(context, initialData);
 
-      const updatedData: TestModel = {
+      const updatedData: UserProfile = {
         ...initialData,
-        campaignName: 'new-name',
+        username: 'charlie',
       };
 
-      updateModel(context, updatedData, undefined, {
-        changedPaths: [['campaignName']],
-      });
+      updateModel(context, updatedData, undefined, undefined, [['username']]);
 
       const data = getModelData(context);
-      expect(data.computed).toBe('computed:new-name');
+      expect(data.displayName).toBe('@charlie');
     });
   });
 
   describe('with validations', () => {
     const validateFn = jest.fn();
 
-    const testModel = model<TestModel>((root, builder) => [
-      builder.withFields(root, ['campaignName', 'budget', 'items'], ({ campaignName, budget }) => [
-        builder.validate(campaignName, { budget }, validateFn),
+    const testModel = model<UserProfile>((root, builder) => [
+      builder.withFields(root, ['username', 'age', 'tags'], ({ username, age }) => [
+        builder.validate(username, { age }, validateFn),
       ]),
     ]);
 
@@ -86,20 +82,18 @@ describe('updateModel with changedPaths', () => {
 
       validateFn.mockClear();
 
-      const updatedData: TestModel = {
+      const updatedData: UserProfile = {
         ...initialData,
-        campaignName: 'updated',
+        username: 'bob',
       };
 
-      updateModel(context, updatedData, undefined, {
-        changedPaths: [['campaignName']],
-      });
+      updateModel(context, updatedData, undefined, undefined, [['username']]);
 
       expect(validateFn).toHaveBeenCalled();
     });
 
     it('should produce the same validation errors with and without hint', () => {
-      const validationError = 'name too short';
+      const validationError = 'username too short';
       validateFn.mockReturnValue(validationError);
 
       const contextWithHint = createValidationContext(testModel);
@@ -108,14 +102,12 @@ describe('updateModel with changedPaths', () => {
       updateModel(contextWithHint, initialData);
       updateModel(contextWithoutHint, initialData);
 
-      const updatedData: TestModel = {
+      const updatedData: UserProfile = {
         ...initialData,
-        campaignName: 'x',
+        username: 'x',
       };
 
-      updateModel(contextWithHint, updatedData, undefined, {
-        changedPaths: [['campaignName']],
-      });
+      updateModel(contextWithHint, updatedData, undefined, undefined, [['username']]);
 
       updateModel(contextWithoutHint, updatedData);
 
@@ -124,40 +116,34 @@ describe('updateModel with changedPaths', () => {
   });
 
   describe('with conditions', () => {
-    const testModel = model<TestModel>((root, builder) => [
-      builder.withFields(
-        root,
-        ['campaignName', 'budget', 'computed', 'items'],
-        ({ campaignName, budget, computed }) => [
-          builder.when(
-            campaignName,
-            (name: string) => name === 'active',
-            () => [
-              builder.value(
-                computed,
-                builder.compute(budget, (b: number) => `budget:${b}`),
-              ),
-            ],
-          ),
-        ],
-      ),
+    const testModel = model<UserProfile>((root, builder) => [
+      builder.withFields(root, ['username', 'age', 'displayName', 'tags'], ({ username, age, displayName }) => [
+        builder.when(
+          username,
+          (name: string) => name === 'admin',
+          () => [
+            builder.value(
+              displayName,
+              builder.compute(age, (a: number) => `admin:${a}`),
+            ),
+          ],
+        ),
+      ]),
     ]);
 
     it('should produce the same model data with and without hint when condition triggers', () => {
       const contextWithHint = createValidationContext(testModel);
       const contextWithoutHint = createValidationContext(testModel);
 
-      updateModel(contextWithHint, { ...initialData, campaignName: 'inactive' });
-      updateModel(contextWithoutHint, { ...initialData, campaignName: 'inactive' });
+      updateModel(contextWithHint, { ...initialData, username: 'guest' });
+      updateModel(contextWithoutHint, { ...initialData, username: 'guest' });
 
-      const updatedData: TestModel = {
+      const updatedData: UserProfile = {
         ...initialData,
-        campaignName: 'active',
+        username: 'admin',
       };
 
-      updateModel(contextWithHint, updatedData, undefined, {
-        changedPaths: [['campaignName']],
-      });
+      updateModel(contextWithHint, updatedData, undefined, undefined, [['username']]);
 
       updateModel(contextWithoutHint, updatedData);
 
@@ -166,54 +152,56 @@ describe('updateModel with changedPaths', () => {
   });
 
   describe('with array item changes', () => {
-    type ArrayModel = {
-      list: { name: string; computed?: string }[];
+    type ContactList = {
+      contacts: { email: string; normalized?: string }[];
     };
 
-    const testModel = model<ArrayModel>((root, builder) => [
-      builder.field(root, 'list', list => [
-        builder.array(list, item => [
-          builder.withFields(item, ['name', 'computed'], ({ name, computed }) => [
+    const testModel = model<ContactList>((root, builder) => [
+      builder.field(root, 'contacts', contacts => [
+        builder.array(contacts, item => [
+          builder.withFields(item, ['email', 'normalized'], ({ email, normalized }) => [
             builder.value(
-              computed,
-              builder.compute(name, (n: string) => `upper:${n.toUpperCase()}`),
+              normalized,
+              builder.compute(email, (e: string) => e.toLowerCase().trim()),
             ),
           ]),
         ]),
       ]),
     ]);
 
-    const arrayInitialData: ArrayModel = {
-      list: [{ name: 'alice' }, { name: 'bob' }, { name: 'charlie' }],
+    const contactsInitialData: ContactList = {
+      contacts: [{ email: 'Alice@test.com' }, { email: 'Bob@test.com' }, { email: 'Charlie@test.com' }],
     };
 
     it('should produce the same model data when changing an array item field', () => {
       const contextWithHint = createValidationContext(testModel);
       const contextWithoutHint = createValidationContext(testModel);
 
-      updateModel(contextWithHint, arrayInitialData);
-      updateModel(contextWithoutHint, arrayInitialData);
+      updateModel(contextWithHint, contactsInitialData);
+      updateModel(contextWithoutHint, contactsInitialData);
 
       // use model data (which includes computed values) as the base for the next update,
-      // matching how campaign-manager feeds Yavl: always passing the latest model data back
+      // matching how form libraries feed Yavl: always passing the latest model data back
       const modelDataWithHint = getModelData(contextWithHint);
       const modelDataWithoutHint = getModelData(contextWithoutHint);
 
-      const updatedForHint: ArrayModel = {
-        list: [{ ...modelDataWithHint.list[0], name: 'ALICE' }, modelDataWithHint.list[1], modelDataWithHint.list[2]],
-      };
-
-      const updatedForNoHint: ArrayModel = {
-        list: [
-          { ...modelDataWithoutHint.list[0], name: 'ALICE' },
-          modelDataWithoutHint.list[1],
-          modelDataWithoutHint.list[2],
+      const updatedForHint: ContactList = {
+        contacts: [
+          { ...modelDataWithHint.contacts[0], email: 'New@test.com' },
+          modelDataWithHint.contacts[1],
+          modelDataWithHint.contacts[2],
         ],
       };
 
-      updateModel(contextWithHint, updatedForHint, undefined, {
-        changedPaths: [['list', 0, 'name']],
-      });
+      const updatedForNoHint: ContactList = {
+        contacts: [
+          { ...modelDataWithoutHint.contacts[0], email: 'New@test.com' },
+          modelDataWithoutHint.contacts[1],
+          modelDataWithoutHint.contacts[2],
+        ],
+      };
+
+      updateModel(contextWithHint, updatedForHint, undefined, undefined, [['contacts', 0, 'email']]);
 
       updateModel(contextWithoutHint, updatedForNoHint);
 
@@ -222,37 +210,35 @@ describe('updateModel with changedPaths', () => {
 
     it('should update the computed value for the changed array item', () => {
       const context = createValidationContext(testModel);
-      updateModel(context, arrayInitialData);
+      updateModel(context, contactsInitialData);
 
       const modelData = getModelData(context);
 
-      const updatedData: ArrayModel = {
-        list: [{ ...modelData.list[0], name: 'updated' }, modelData.list[1], modelData.list[2]],
+      const updatedData: ContactList = {
+        contacts: [
+          { ...modelData.contacts[0], email: '  Updated@TEST.com  ' },
+          modelData.contacts[1],
+          modelData.contacts[2],
+        ],
       };
 
-      updateModel(context, updatedData, undefined, {
-        changedPaths: [['list', 0, 'name']],
-      });
+      updateModel(context, updatedData, undefined, undefined, [['contacts', 0, 'email']]);
 
       const data = getModelData(context);
-      expect(data.list[0].computed).toBe('upper:UPDATED');
-      expect(data.list[1].computed).toBe('upper:BOB');
-      expect(data.list[2].computed).toBe('upper:CHARLIE');
+      expect(data.contacts[0].normalized).toBe('updated@test.com');
+      expect(data.contacts[1].normalized).toBe('bob@test.com');
+      expect(data.contacts[2].normalized).toBe('charlie@test.com');
     });
   });
 
   describe('with multiple changedPaths', () => {
-    const testModel = model<TestModel>((root, builder) => [
-      builder.withFields(
-        root,
-        ['campaignName', 'budget', 'computed', 'items'],
-        ({ campaignName, budget, computed }) => [
-          builder.value(
-            computed,
-            builder.compute({ campaignName, budget }, ({ campaignName: n, budget: b }) => `${n}:${b}`),
-          ),
-        ],
-      ),
+    const testModel = model<UserProfile>((root, builder) => [
+      builder.withFields(root, ['username', 'age', 'displayName', 'tags'], ({ username, age, displayName }) => [
+        builder.value(
+          displayName,
+          builder.compute({ username, age }, ({ username: n, age: a }) => `${n}:${a}`),
+        ),
+      ]),
     ]);
 
     it('should handle multiple fields changing at once', () => {
@@ -262,20 +248,18 @@ describe('updateModel with changedPaths', () => {
       updateModel(contextWithHint, initialData);
       updateModel(contextWithoutHint, initialData);
 
-      const updatedData: TestModel = {
+      const updatedData: UserProfile = {
         ...initialData,
-        campaignName: 'new-name',
-        budget: 999,
+        username: 'bob',
+        age: 25,
       };
 
-      updateModel(contextWithHint, updatedData, undefined, {
-        changedPaths: [['campaignName'], ['budget']],
-      });
+      updateModel(contextWithHint, updatedData, undefined, undefined, [['username'], ['age']]);
 
       updateModel(contextWithoutHint, updatedData);
 
       expect(getModelData(contextWithHint)).toEqual(getModelData(contextWithoutHint));
-      expect(getModelData(contextWithHint).computed).toBe('new-name:999');
+      expect(getModelData(contextWithHint).displayName).toBe('bob:25');
     });
   });
 
@@ -301,9 +285,7 @@ describe('updateModel with changedPaths', () => {
 
       const cascadeUpdated: CascadeModel = { a: 'changed' };
 
-      updateModel(contextWithHint, cascadeUpdated, undefined, {
-        changedPaths: [['a']],
-      });
+      updateModel(contextWithHint, cascadeUpdated, undefined, undefined, [['a']]);
 
       updateModel(contextWithoutHint, cascadeUpdated);
 
@@ -317,37 +299,40 @@ describe('updateModel with changedPaths', () => {
   });
 
   describe('backward compatibility', () => {
-    const testModel = model<TestModel>((root, builder) => [
-      builder.withFields(root, ['campaignName', 'budget', 'computed', 'items'], ({ campaignName, computed }) => [
+    const testModel = model<UserProfile>((root, builder) => [
+      builder.withFields(root, ['username', 'age', 'displayName', 'tags'], ({ username, displayName }) => [
         builder.value(
-          computed,
-          builder.compute(campaignName, (name: string) => `computed:${name}`),
+          displayName,
+          builder.compute(username, (name: string) => `@${name}`),
         ),
       ]),
     ]);
 
-    it('should work when called with isEqualFn as a function (legacy signature)', () => {
+    it('should work when called with isEqualFn as a function', () => {
       const context = createValidationContext(testModel);
       updateModel(context, initialData, undefined, Object.is);
 
       const data = getModelData(context);
-      expect(data.computed).toBe('computed:test');
+      expect(data.displayName).toBe('@alice');
     });
 
-    it('should work when called without 4th argument', () => {
+    it('should work when called without optional arguments', () => {
       const context = createValidationContext(testModel);
       updateModel(context, initialData);
 
       const data = getModelData(context);
-      expect(data.computed).toBe('computed:test');
+      expect(data.displayName).toBe('@alice');
     });
 
-    it('should work when called with options object', () => {
+    it('should work when called with both isEqualFn and changedPaths', () => {
       const context = createValidationContext(testModel);
-      updateModel(context, initialData, undefined, { isEqualFn: Object.is });
+      updateModel(context, initialData);
+
+      const updatedData: UserProfile = { ...initialData, username: 'bob' };
+      updateModel(context, updatedData, undefined, Object.is, [['username']]);
 
       const data = getModelData(context);
-      expect(data.computed).toBe('computed:test');
+      expect(data.displayName).toBe('@bob');
     });
   });
 });


### PR DESCRIPTION
**Long story short**

When the caller knows which field changed, we skip the full-tree diff and instead expand only the changed path into its ancestor prefixes (filtered by the dependency registry). Subsequent cascading passes still use the full diff for correctness. This should cut down lag drastically as traversal of large models can become expensive quite quickly.

**Skip full-tree diff when caller knows which paths changed**

When updateModel is called after a user edits a single form field, Yavl currently diffs the entire data tree against the previous state to find what changed (`getChangedData`). For large forms, this recursive traversal is expensive and redundant -- the caller already knows which path the user edited.

This change lets callers optionally pass `changedPaths` to `updateModel`. When provided, the first pass of processModelChanges skips the full-tree diff entirely and instead expands the given leaf paths into all ancestor prefixes filtered by `fieldsWithDependencies`.
Subsequent passes (triggered by cascading computed values) still use the full `getChangedData` diff to catch any side effects, so correctness is preserved.

What changed:

* `updateModel` accepts two new optional arguments: `isEqualFn` (4th, same as before) and `changedPaths` (5th). The existing signature is fully backward compatible.
* `processModelChanges` receives the optional `changedPaths` and on pass 0, delegates to the new `expandChangedPaths` helper instead of `getChangedData`.
* `expandChangedPaths` takes the leaf paths (e.g., `['model', 0, 'fields', 'name']`), generates all prefixes (root, model, model[0], ..., the leaf itself), strips array indices for the `fieldsWithDependencies` lookup, deduplicates, and filters by the same `shouldIncludeField` logic that `getChangedData` uses.
* `shouldIncludeField` in `getChangedData.ts` is now exported so `expandChangedPaths` can reuse it.

What didn't change:

* Callers that don't pass `changedPaths` get the exact same behavior as before. No existing API contract is broken.
* Pass > 0 (cascading computed value changes) always uses the full `getChangedData` diff, so computed cascades are handled correctly.
* `validateModel` and all other public APIs are unaffected.

Why this helps:

For a large model, `getChangedData` can consume ~25% of per-keystroke CPU time by walking the entire tree on every edit. With `changedPaths`, that first-pass cost drops to `O(depth of changed path)` instead of `O(total number of fields in the tree)`. The full diff only runs if computed values actually cascade changes to other parts of the tree.

Tests:

* 11 unit tests for `expandChangedPaths`: ancestor expansion, changesFor filtering, deduplication, nested arrays, edge cases (empty paths, unregistered paths, single-segment paths).
* 12 integration tests for `updateModel` with `changedPaths`: verifies identical results (model data, validation errors) with and without hints for computed values, validations, conditions, array items, multiple simultaneous changed paths, cascading computed values across multiple passes, and backward compatibility with the legacy `CompareFn` signature.